### PR TITLE
change child route on new rank

### DIFF
--- a/lib/libndmgmt/dag.cpp
+++ b/lib/libndmgmt/dag.cpp
@@ -417,12 +417,10 @@ bool dag_network::check_security(const struct nd_rpl_dao *dao, int dao_len)
 /* here we mark that a DAO is needed soon */
 void dag_network::maybe_send_dao(void)
 {
-    if(dao_needed && dag_bestparent != NULL) {
-        if(!root_node()) {
-            schedule_dao();
-        }
-        dao_needed = false;
+    if(dao_needed && dag_bestparent && !root_node()) {
+        schedule_dao();
     }
+    dao_needed = false;
 }
 
 void dag_network::add_childnode(rpl_node          *announcing_peer,
@@ -433,7 +431,7 @@ void dag_network::add_childnode(rpl_node          *announcing_peer,
     char b1[256];
     subnettot(&prefix, 0, b1, 256);
 
-    if(!pre.is_installed()) {
+    //if(!pre.is_installed()) {
         dao_needed = true;
         pre.set_debug(this->debug);
         pre.set_prefix(prefix);
@@ -442,7 +440,7 @@ void dag_network::add_childnode(rpl_node          *announcing_peer,
         announcing_peer->add_route_via_node(prefix, iface);
         set_dao_needed();
         pre.set_installed(true);
-    }
+    //}
 #if 0
     debug->verbose("added child node %s/%s from %s\n",
                    b1, pre.node_name(),
@@ -1133,4 +1131,3 @@ bool dag_network::set_interface_filter(const char *filter)
  * compile-command: "make programs"
  * End:
  */
-

--- a/lib/libndmgmt/netlink.cpp
+++ b/lib/libndmgmt/netlink.cpp
@@ -192,7 +192,7 @@ bool network_interface::add_route_to_node(const ip_subnet &prefix,
     addrtot(&src,                 0, sbuf, sizeof(sbuf));
 
     snprintf(buf, 1024,
-             "ip -6 route add %s via %s dev %s src %s", pbuf, tbuf, if_name, sbuf);
+             "ip -6 route replace %s via %s dev %s src %s", pbuf, tbuf, if_name, sbuf);
 
     debug->log("  invoking %s\n", buf);
     nisystem(buf);


### PR DESCRIPTION
This PR fixes the following issue I observed when using `sunshine` as RPL root on a RPi with OpenLabs transceiver and 2 sensor nodes running [RIOT gnrc_networking example](https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking). 

RPL root (`sunshine`) has rank 1, the first RIOT nodes takes up rank 257, after sending a DAO `sunshine` adds a route to that first child node. Starting the second RIOT node it first chooses the other RIOT node as parent, hence has rank 513. When `sunshine` _hears_ the DAO of the second node it correctly implements a route via the first RIOT node as first hop. 

However, when `sunshine` sends its next DIO both RIOT nodes receive that and the second RIOT node changes its parent to the RPL root node running `sunshine`, hence adapting its rank to 257 as the first RIOT node. After `sunshine` _hears_ the DAO it should change the route for the second node, that is changing the next hop. Without this fix, this does not happen, `sunshine` would still assume to reach the second node via the first one - any packet from RPL root to the second child would end up in a loop, bouncing back-and-forth between root and the first (child) node. 

My fix changes the command from `ip -6 route add ...` to `ip -6 route replace ...` which changes the next hop if route already present or adds a new route if none exists.

The code changes are minor and not _beautiful_, I didn't take the time to apply coding conventions. As I read in the code, the respective commands are bound to change to use netlink. However, this fix is required otherwise `sunshine` does not adapt to route changes of its children. 
